### PR TITLE
feat: ✨ #16 close sidemenu after clicking link

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="flex justify-between items-center z-50">
+  <header class="flex justify-between items-center z-10">
     <nuxt-link to="/">
       <h1
         class="hover:text-hover-gray font-bold text-pale-gray sm:tracking-wide text-2xl md:text-3xl lg:pl-16 md:pl-10 sm:pl-6 pl-3 h-8"
@@ -16,37 +16,7 @@
       />
       <div
         class="bg-pale-green h-16 w-16 md:h-24 md:w-24 flex justify-center items-center"
-      >
-        <unicon
-          class="cursor-pointer"
-          :fill="fill"
-          :width="width"
-          :height="height"
-          :name="isActive ? 'bars' : 'times'"
-          @click="onClick"
-        />
-      </div>
+      ></div>
     </div>
   </header>
 </template>
-
-<script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  data() {
-    return {
-      fill: '#969383',
-      height: '45',
-      width: '45',
-      name: 'bars',
-      isActive: true,
-    }
-  },
-  methods: {
-    onClick() {
-      this.isActive = !this.isActive
-      this.$emit('hamburgerClick')
-    },
-  },
-})
-</script>

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -15,13 +15,13 @@
       :class="{ hidden: isHidden }"
     >
       <ul class="pt-48 pb-24 pl-12">
-        <li class="mb-10 hover:text-hover-gray">
+        <li class="mb-10 hover:text-hover-gray" @click="onClick">
           <nuxt-link to="/">Posts</nuxt-link>
         </li>
-        <li class="mb-10 hover:text-hover-gray">
+        <li class="mb-10 hover:text-hover-gray" @click="onClick">
           <nuxt-link to="../categories">Categories</nuxt-link>
         </li>
-        <li class="mb-10 hover:text-hover-gray">
+        <li class="mb-10 hover:text-hover-gray" @click="onClick">
           <nuxt-link to="../about">About</nuxt-link>
         </li>
       </ul>

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -1,18 +1,47 @@
 <template>
-  <nav
-    class="h-screen fixed top-0 right-0 bg-pale-green text-pale-gray z-0 w-48"
-  >
-    <ul class="pt-48 pb-24 pl-12">
-      <li class="mb-10 hover:text-hover-gray">
-        <nuxt-link to="/">Posts</nuxt-link>
-      </li>
-      <li class="mb-10 hover:text-hover-gray">
-        <nuxt-link to="../categories">Categories</nuxt-link>
-      </li>
-      <li class="mb-10 hover:text-hover-gray">
-        <nuxt-link to="../about">About</nuxt-link>
-      </li>
-    </ul>
-    <SnsIcons width="20" height="20" classes="cursor-pointer pr-3" />
-  </nav>
+  <div>
+    <div>
+      <unicon
+        :name="isHidden ? 'bars' : 'times'"
+        fill="#969383"
+        width="45"
+        height="45"
+        class="z-20 fixed right-0 top-0 mr-3 mt-3 md:mr-6 md:mt-6 cursor-pointer"
+        @click="onClick"
+      />
+    </div>
+    <nav
+      class="h-screen fixed top-0 right-0 bg-pale-green text-pale-gray z-0 w-48"
+      :class="{ hidden: isHidden }"
+    >
+      <ul class="pt-48 pb-24 pl-12">
+        <li class="mb-10 hover:text-hover-gray">
+          <nuxt-link to="/">Posts</nuxt-link>
+        </li>
+        <li class="mb-10 hover:text-hover-gray">
+          <nuxt-link to="../categories">Categories</nuxt-link>
+        </li>
+        <li class="mb-10 hover:text-hover-gray">
+          <nuxt-link to="../about">About</nuxt-link>
+        </li>
+      </ul>
+      <SnsIcons width="20" height="20" classes="cursor-pointer pr-3" />
+    </nav>
+  </div>
 </template>
+
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({
+  data() {
+    return {
+      isHidden: true,
+    }
+  },
+  methods: {
+    onClick() {
+      this.isHidden = !this.isHidden
+    },
+  },
+})
+</script>

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -10,7 +10,7 @@
         <nuxt-link to="../categories">Categories</nuxt-link>
       </li>
       <li class="mb-10 hover:text-hover-gray">
-        <nuxt-link to="about">About</nuxt-link>
+        <nuxt-link to="../about">About</nuxt-link>
       </li>
     </ul>
     <SnsIcons width="20" height="20" classes="cursor-pointer pr-3" />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,34 +1,18 @@
 <template>
   <!-- sticky footer -->
   <div class="min-h-screen flex flex-col">
-    <Header @hamburgerClick="hiddenSidebar" />
+    <Header />
     <div class="flex flex-1">
       <Container>
         <Main>
           <Nuxt />
         </Main>
       </Container>
-      <SideBar :class="{ hidden: isHidden }" />
+      <SideBar />
     </div>
     <Footer />
   </div>
 </template>
-
-<script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  data() {
-    return {
-      isHidden: true,
-    }
-  },
-  methods: {
-    hiddenSidebar() {
-      this.isHidden = !this.isHidden
-    },
-  },
-})
-</script>
 
 <style>
 html {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -22,5 +22,6 @@ html {
   color: #5e5e5e;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+  user-select: none;
 }
 </style>

--- a/pages/posts/_slug.vue
+++ b/pages/posts/_slug.vue
@@ -1,5 +1,5 @@
 <template>
-  <article>
+  <article class="select-text">
     <div class="xl:ml-24 lg:ml-12 -ml-2 sm:mb-24 mb-16 items-end">
       <h1
         class="font-bold my-2 py-1 mr-4 pl-4 border-l-8 border-pale-pink md:text-3xl text-2xl"


### PR DESCRIPTION
## 👏 Resolved Issues
close #16 

## ⛏ Details of Changes
- Make the side menu close when the link is clicked.
- Move the hamburger icon from header to side-menu.
- Change user-select to none, except for the article detail page.